### PR TITLE
Fix: Automate redirect to dashboard after login

### DIFF
--- a/app/retake_apply/states/auth.py
+++ b/app/retake_apply/states/auth.py
@@ -121,6 +121,10 @@ class AuthState(GoogleAuthState):
                     # 理論上，若 token_is_valid 為 True，google_sub 應該存在。
                     self._app_user_groups_var = []
                     console.error("Google 登入成功，但無法從 tokeninfo 中獲取 'sub' (Google User ID)。")
+            
+            # If token was valid and user processing is done, redirect to dashboard.
+            if self.token_is_valid: # Double check token_is_valid before redirect
+                return rx.redirect("/dashboard")
             else:
                 # Token 無效，清除群組資訊
                 self._app_user_groups_var = []


### PR DESCRIPTION
You were not automatically redirected to /dashboard after a successful login.

This commit modifies the `AuthState.on_success` method to explicitly return `rx.redirect("/dashboard")` after all user processing has successfully completed and the auth token is verified as valid. This ensures a consistent user experience by navigating you to the dashboard post-authentication.